### PR TITLE
fixed dropdown menu not closing

### DIFF
--- a/lib/search_choices.dart
+++ b/lib/search_choices.dart
@@ -1227,7 +1227,7 @@ class _SearchChoicesState<T> extends State<SearchChoices<T>> {
         }
       }
     } else {
-      displayMenu.value = true;
+      displayMenu.value = !displayMenu.value;
     }
     if (mounted) {
       setState(() {});


### PR DESCRIPTION
the value should be turned into false when the menu is already opened (the value is already true)
One of the #63 items 