### PR TITLE
Upgrade Gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,12 +2,11 @@ group 'li.jod.search_choices'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.8.22'
+    ext.kotlin_version = '1.9.0'
     repositories {
         google()
         mavenCentral()
     }
-
     dependencies {
         classpath 'com.android.tools.build:gradle:7.4.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -25,22 +24,33 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 33
-
+    compileSdkVersion 34
     namespace = "li.jod.search_choices"
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
+
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 19
+        targetSdkVersion 34
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
+
     lintOptions {
         disable 'InvalidPackage'
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = '17'
     }
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 }


### PR DESCRIPTION
### Summary
This PR updates the Android Gradle and Kotlin versions, as well as the Android SDK configurations to align with the latest standards and improve compatibility.

### Changes:
- Upgraded Kotlin version to `1.9.0` to ensure compatibility with the latest Kotlin features.
- Set `compileSdkVersion` to `34` and `targetSdkVersion` to `34` for Android compatibility with newer APIs.
- Updated `sourceCompatibility` and `targetCompatibility` to Java version 17.
- Updated `kotlinOptions` to use JVM target `17`.

### Related Issue:
- Addressing issue reported here: [#125](https://github.com/lcuis/search_choices/issues/125#issue-2413038427)

Tested successfully with Flutter 3.24.2 and Gradle version 8.10.1.